### PR TITLE
Feature/#7 post diary

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ import BakeryEditReviewPage from "./pages/bakery/BakeryEditReviewPage";
 
 import DiaryCalenderPage from "./pages/diary/DiaryCalendarPage";
 import DiaryEditorPage from "./pages/diary/DiaryEditorPage";
+import DiaryBakeryPage from "./pages/diary/BakeryPage";
 
 import CommunityPage from "./pages/community/CommunityPage";
 import MapPage from "./pages/map/MapPage";
@@ -68,6 +69,7 @@ function App() {
         <Route element={<AppLayout />}>
           <Route path="/mydiary" element={<DiaryCalenderPage />} />
           <Route path="/diary/new" element={<DiaryEditorPage />} />
+          <Route path="/diary/bakery" element={<DiaryBakeryPage />} />
         </Route>
         <Route
           element={

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import BakeryEditReviewPage from "./pages/bakery/BakeryEditReviewPage";
 import DiaryCalenderPage from "./pages/diary/DiaryCalendarPage";
 import DiaryEditorPage from "./pages/diary/DiaryEditorPage";
 import DiaryBakeryPage from "./pages/diary/BakeryPage";
+import DiaryDetailPage from "./pages/diary/DiaryDetailPage";
 
 import CommunityPage from "./pages/community/CommunityPage";
 import MapPage from "./pages/map/MapPage";
@@ -90,6 +91,7 @@ function App() {
           <Route path="/bakery" element={<BakeryPage />} />
           <Route path="/bakery/:id" element={<BakeryDetailPage />} />
           <Route path="/community" element={<CommunityPage />} />
+          <Route path="/community/diary/:diaryId" element={<DiaryDetailPage />} />
           <Route path="/map" element={<MapPage />} />
         </Route>
       </Routes>

--- a/src/components/diary/EditorHeader.jsx
+++ b/src/components/diary/EditorHeader.jsx
@@ -1,11 +1,15 @@
-import React from "react";
+﻿import React from "react";
 import { useNavigate } from "react-router-dom";
 import * as S from "./EditorHeader.styled";
 import BackMark from "../../assets/BackMark.svg";
 import saveDraftIcon from "../../assets/saveDraftIcon.png";
 import saveIcon from "../../assets/saveIcon.png";
 
-export default function DiaryEditorHeader({ title = "다이어리 작성하기" }) {
+export default function DiaryEditorHeader({
+  title = "다이어리 작성하기",
+  onSubmit,
+  isSubmitting = false,
+}) {
   const navigate = useNavigate();
 
   return (
@@ -23,10 +27,15 @@ export default function DiaryEditorHeader({ title = "다이어리 작성하기" 
       <S.Title>{title}</S.Title>
 
       <S.Right>
-        <S.IconButton type="button" aria-label="action-1">
+        <S.IconButton type="button" aria-label="save-draft">
           <S.IconImg src={saveDraftIcon} alt="임시저장" />
         </S.IconButton>
-        <S.IconButton type="button" aria-label="action-2">
+        <S.IconButton
+          type="button"
+          aria-label="save-diary"
+          onClick={onSubmit}
+          disabled={isSubmitting}
+        >
           <S.IconImg src={saveIcon} alt="저장" />
         </S.IconButton>
       </S.Right>

--- a/src/components/diary/EditorTabBar.jsx
+++ b/src/components/diary/EditorTabBar.jsx
@@ -192,6 +192,7 @@ export default function EditorTabBar() {
   };
 
   const handleDrawDone = () => {
+    setIsPaletteOpen(false);
     setActiveTab("draw");
     setTool("pen");
   };

--- a/src/components/diary/EditorTabBar.jsx
+++ b/src/components/diary/EditorTabBar.jsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+﻿import React, { useRef, useState } from "react";
 import * as S from "./EditorTabBar.styled";
 import { useDiaryEditorStore } from "../../store/diaryEditorStore";
 
@@ -17,7 +17,10 @@ const DRAW_COLORS = [
   "#FFFFFF",
 ];
 
-// ─── 탭바 아이콘 SVG ──────────────────────────────────────────────
+const FONT_OPTIONS = [
+  { key: "pretendard", label: "Pretendard" },
+  { key: "fredoka", label: "Fredoka" },
+];
 
 function FontIcon() {
   return <S.AaText>Aa</S.AaText>;
@@ -76,8 +79,6 @@ function PencilIcon() {
     </svg>
   );
 }
-
-// ─── 그림판 컨트롤 아이콘 SVG ─────────────────────────────────────
 
 function UndoIcon() {
   return (
@@ -149,8 +150,6 @@ function CheckIcon() {
   );
 }
 
-// ─── 메인 컴포넌트 ────────────────────────────────────────────────
-
 export default function EditorTabBar() {
   const imageInputRef = useRef(null);
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
@@ -162,6 +161,7 @@ export default function EditorTabBar() {
   const brushSize = useDiaryEditorStore((s) => s.brushSize);
   const strokes = useDiaryEditorStore((s) => s.strokes);
   const undoneStrokes = useDiaryEditorStore((s) => s.undoneStrokes);
+  const textFont = useDiaryEditorStore((s) => s.textFont);
 
   const setActiveTab = useDiaryEditorStore((s) => s.setActiveTab);
   const setIsPublic = useDiaryEditorStore((s) => s.setIsPublic);
@@ -169,6 +169,7 @@ export default function EditorTabBar() {
   const setColor = useDiaryEditorStore((s) => s.setColor);
   const setBrushSize = useDiaryEditorStore((s) => s.setBrushSize);
   const setBaseImage = useDiaryEditorStore((s) => s.setBaseImage);
+  const setTextFont = useDiaryEditorStore((s) => s.setTextFont);
   const undoStroke = useDiaryEditorStore((s) => s.undoStroke);
   const redoStroke = useDiaryEditorStore((s) => s.redoStroke);
   const clearStrokes = useDiaryEditorStore((s) => s.clearStrokes);
@@ -190,12 +191,50 @@ export default function EditorTabBar() {
     setIsPaletteOpen(false);
   };
 
-  const handleDone = () => {
-    setActiveTab("draw"); // 같은 탭 재클릭 → 닫기(null)
+  const handleDrawDone = () => {
+    setActiveTab("draw");
     setTool("pen");
   };
 
-  // ── 그림판 모드 ──
+  const handleFontDone = () => {
+    setActiveTab("font");
+  };
+
+  if (activeTab === "font") {
+    return (
+      <S.BarWrapper>
+        <S.BarInner>
+          <S.FontWrap>
+            <S.MainPill $mode="draw">
+              <S.FontControlsRow>
+                {FONT_OPTIONS.map((option) => (
+                  <S.FontOptionBtn
+                    key={option.key}
+                    type="button"
+                    $fontKey={option.key}
+                    $active={textFont === option.key}
+                    onClick={() => setTextFont(option.key)}
+                    aria-label={`${option.label} 폰트 선택`}
+                  >
+                    {option.label}
+                  </S.FontOptionBtn>
+                ))}
+                <S.TabBtnLike
+                  type="button"
+                  $done
+                  onClick={handleFontDone}
+                  aria-label="폰트 선택 완료"
+                >
+                  <CheckIcon />
+                </S.TabBtnLike>
+              </S.FontControlsRow>
+            </S.MainPill>
+          </S.FontWrap>
+        </S.BarInner>
+      </S.BarWrapper>
+    );
+  }
+
   if (activeTab === "draw") {
     return (
       <S.BarWrapper>
@@ -216,9 +255,7 @@ export default function EditorTabBar() {
               </S.PalettePopover>
             )}
 
-            {/* 드로잉 컨트롤 */}
             <S.MainPill $mode="draw">
-              {/* 현재 색상 미리보기 */}
               <S.CurrentColorBtn
                 type="button"
                 $color={color}
@@ -227,27 +264,25 @@ export default function EditorTabBar() {
                   setTool("pen");
                   setIsPaletteOpen((v) => !v);
                 }}
-                aria-label="펜 선택"
+                aria-label="색상 선택"
               />
 
-              {/* 지우개 */}
               <S.TabBtnLike
                 type="button"
                 $active={tool === "eraser"}
                 onClick={() => setTool(tool === "eraser" ? "pen" : "eraser")}
                 aria-label="지우개"
               >
-                <img src={Eraser} />
+                <img src={Eraser} alt="" />
               </S.TabBtnLike>
 
-              {/* 굵기 */}
               <S.SizePill>
                 <S.SizeBtn
                   type="button"
                   onClick={() => setBrushSize(Math.max(1, brushSize - 1))}
                   aria-label="굵기 감소"
                 >
-                  −
+                  -
                 </S.SizeBtn>
                 <S.SizeNum>{brushSize}</S.SizeNum>
                 <S.SizeBtn
@@ -259,7 +294,6 @@ export default function EditorTabBar() {
                 </S.SizeBtn>
               </S.SizePill>
 
-              {/* 실행취소 */}
               <S.TabBtnLike
                 type="button"
                 disabled={strokes.length === 0}
@@ -269,7 +303,6 @@ export default function EditorTabBar() {
                 <UndoIcon />
               </S.TabBtnLike>
 
-              {/* 다시실행 */}
               <S.TabBtnLike
                 type="button"
                 disabled={undoneStrokes.length === 0}
@@ -279,7 +312,6 @@ export default function EditorTabBar() {
                 <RedoIcon />
               </S.TabBtnLike>
 
-              {/* 전체 지우기 */}
               <S.TabBtnLike
                 type="button"
                 onClick={clearStrokes}
@@ -288,11 +320,10 @@ export default function EditorTabBar() {
                 <TrashIcon />
               </S.TabBtnLike>
 
-              {/* 완료 */}
               <S.TabBtnLike
                 type="button"
                 $done
-                onClick={handleDone}
+                onClick={handleDrawDone}
                 aria-label="완료"
               >
                 <CheckIcon />
@@ -304,7 +335,6 @@ export default function EditorTabBar() {
     );
   }
 
-  // ── 기본 탭바 ──
   return (
     <S.BarWrapper>
       <S.BarInner>
@@ -345,7 +375,7 @@ export default function EditorTabBar() {
             type="button"
             $active={activeTab === "draw"}
             onClick={() => setActiveTab("draw")}
-            aria-label="그림판 열기"
+            aria-label="그림 그리기"
           >
             <PencilIcon />
           </S.TabBtn>

--- a/src/components/diary/EditorTabBar.styled.js
+++ b/src/components/diary/EditorTabBar.styled.js
@@ -124,6 +124,33 @@ export const DrawWrap = styled.div`
   width: 100%;
 `;
 
+export const FontWrap = styled.div`
+  width: 100%;
+`;
+
+export const FontControlsRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+export const FontOptionBtn = styled.button`
+  flex: 1;
+  height: 36px;
+  border-radius: 18px;
+  border: 1.5px solid ${BROWN};
+  background: ${({ $active }) =>
+    $active ? "rgba(124,70,40,0.14)" : "transparent"};
+  color: ${BROWN};
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 600;
+  font-family: ${({ $fontKey }) =>
+    $fontKey === "fredoka"
+      ? '"Fredoka", "Pretendard", sans-serif'
+      : '"Pretendard", sans-serif'};
+`;
+
 export const PalettePopover = styled.div`
   position: absolute;
   left: 0;

--- a/src/components/diary/fields/DiaryContentField.jsx
+++ b/src/components/diary/fields/DiaryContentField.jsx
@@ -1,15 +1,17 @@
-import React from "react";
+﻿import React from "react";
 import styled from "styled-components";
 import { useDiaryEditorStore } from "../../../store/diaryEditorStore";
 
 export default function DiaryContentField() {
   const content = useDiaryEditorStore((s) => s.content);
   const setContent = useDiaryEditorStore((s) => s.setContent);
+  const textFont = useDiaryEditorStore((s) => s.textFont);
 
   return (
     <Wrap>
       <Lines />
       <Textarea
+        $font={textFont}
         rows={6}
         value={content}
         onChange={(e) => {
@@ -18,7 +20,7 @@ export default function DiaryContentField() {
           e.target.style.height = "auto";
           e.target.style.height = e.target.scrollHeight + "px";
         }}
-        placeholder="오늘의 빵 이야기를 적어보세요..."
+        placeholder="오늘의 빵 이야기를 적어보세요.."
       />
     </Wrap>
   );
@@ -39,6 +41,10 @@ const Textarea = styled.textarea`
 
   font-size: 16px;
   line-height: 36px;
+  font-family: ${(p) =>
+    p.$font === "fredoka"
+      ? '"Fredoka", "Pretendard", sans-serif'
+      : '"Pretendard", sans-serif'};
 
   padding: 6px 8px;
   box-sizing: border-box;

--- a/src/components/diary/fields/DiaryContentField.jsx
+++ b/src/components/diary/fields/DiaryContentField.jsx
@@ -20,7 +20,7 @@ export default function DiaryContentField() {
           e.target.style.height = "auto";
           e.target.style.height = e.target.scrollHeight + "px";
         }}
-        placeholder="오늘의 빵 이야기를 적어보세요.."
+        placeholder="오늘의 빵 이야기를 적어보세요!"
       />
     </Wrap>
   );

--- a/src/components/diary/fields/DiaryTitleField.jsx
+++ b/src/components/diary/fields/DiaryTitleField.jsx
@@ -13,7 +13,7 @@ export default function DiaryTitleField() {
         id="diary-title"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        placeholder="wpahr"
+        placeholder="제목을 입력해주세요!"
         maxLength={40}
       />
     </Wrap>

--- a/src/components/diary/fields/DiaryTitleField.jsx
+++ b/src/components/diary/fields/DiaryTitleField.jsx
@@ -1,15 +1,17 @@
-import React from "react";
+﻿import React from "react";
 import styled from "styled-components";
 import { useDiaryEditorStore } from "../../../store/diaryEditorStore";
 
 export default function DiaryTitleField() {
   const title = useDiaryEditorStore((s) => s.title);
   const setTitle = useDiaryEditorStore((s) => s.setTitle);
+  const textFont = useDiaryEditorStore((s) => s.textFont);
 
   return (
     <Wrap>
       <Label htmlFor="diary-title">제목:</Label>
       <Input
+        $font={textFont}
         id="diary-title"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
@@ -53,6 +55,10 @@ const Input = styled.input`
   font-size: 16px;
   font-weight: 400;
   color: #ab9d8b;
+  font-family: ${(p) =>
+    p.$font === "fredoka"
+      ? '"Fredoka", "Pretendard", sans-serif'
+      : '"Pretendard", sans-serif'};
 
   outline: none;
 `;

--- a/src/lib/api/diary.js
+++ b/src/lib/api/diary.js
@@ -9,3 +9,7 @@ export async function fetchDiaries({ cursor, size = 10 } = {}) {
 export async function createDiary(body) {
   return apiClient.post("/api/v1/diaries", body);
 }
+
+export async function fetchDiaryDetail(diaryId) {
+  return apiClient.get(`/api/v1/diaries/${diaryId}`);
+}

--- a/src/lib/api/diary.js
+++ b/src/lib/api/diary.js
@@ -5,3 +5,7 @@ export async function fetchDiaries({ cursor, size = 10 } = {}) {
   if (cursor != null) params.set("cursor", String(cursor));
   return apiClient.get(`/api/v1/diaries?${params}`);
 }
+
+export async function createDiary(body) {
+  return apiClient.post("/api/v1/diaries", body);
+}

--- a/src/lib/api/diary.js
+++ b/src/lib/api/diary.js
@@ -11,5 +11,15 @@ export async function createDiary(body) {
 }
 
 export async function fetchDiaryDetail(diaryId) {
-  return apiClient.get(`/api/v1/diaries/${diaryId}`);
+  if (diaryId == null) {
+    throw new TypeError("fetchDiaryDetail requires a diaryId");
+  }
+
+  const normalizedId = String(diaryId).trim();
+  if (!normalizedId) {
+    throw new TypeError("fetchDiaryDetail requires a non-empty diaryId");
+  }
+
+  const encodedId = encodeURIComponent(normalizedId);
+  return apiClient.get(`/api/v1/diaries/${encodedId}`);
 }

--- a/src/pages/community/CommunityPage.jsx
+++ b/src/pages/community/CommunityPage.jsx
@@ -15,9 +15,10 @@ export default function CommunityPage() {
   const sentinelRef = useRef(null);
 
   const goBakery = useCallback((bakeryId) => nav(`/bakery/${bakeryId}`), [nav]);
-  const goPost = useCallback((postId) => {
-    console.log("TODO: go post detail:", postId);
-  }, []);
+  const goPost = useCallback(
+    (postId) => nav(`/community/diary/${postId}`),
+    [nav],
+  );
 
   useEffect(() => {
     const root = mainRef.current;

--- a/src/pages/community/CommunityPage.jsx
+++ b/src/pages/community/CommunityPage.jsx
@@ -194,6 +194,7 @@ const PostCard = styled.button`
   -webkit-appearance: none;
 
   padding: 0 16px;
+  overflow: hidden;
 
   cursor: pointer;
 `;
@@ -215,6 +216,8 @@ const StickerWrap = styled.div`
 `;
 
 const StickerImg = styled.img`
+  width: 100%;
+  height: 100%;
   object-fit: contain;
   transform: rotate(20deg);
 

--- a/src/pages/diary/BakeryPage.jsx
+++ b/src/pages/diary/BakeryPage.jsx
@@ -101,9 +101,7 @@ export default function DiaryBakeryPage() {
           <BakerySelectCard
             key={b.bakeryId}
             name={b.name}
-            address={[b.address?.roadAddress, b.address?.detail]
-              .filter(Boolean)
-              .join(" ")}
+            address={b.address?.roadAddress ?? ""}
             onClick={() => handleSelectBakery(b)}
           />
         ))}

--- a/src/pages/diary/DiaryCalendarPage.jsx
+++ b/src/pages/diary/DiaryCalendarPage.jsx
@@ -1,3 +1,4 @@
+import PageLayout from "../../components/layout/PageLayout";
 import CalendarCard from "../../components/diary/CalendarCard";
 import Header from "../../components/diary/TopHeader";
 import styled from "styled-components";
@@ -39,24 +40,26 @@ export default function DiaryCalenderPage() {
   }, [year, month, selectedDate]);
 
   return (
-    <Screen>
-      <Content>
-        <Header year={year} onYearChange={setYear} />
-        <CardWrap>
-          <CalendarCard
-            year={year}
-            month={month}
-            onPrevMonth={goPrevMonth}
-            onNextMonth={goNextMonth}
-            onSelectDate={setSelectedDate}
-            selectedDay={selectedDate}
-          />
-        </CardWrap>
-        <Fab onClick={() => navigate(`/diary/new?date=${yyyyMmDd}`)}>
-          <img src={AddIcon} alt="새 기록 추가" />
-        </Fab>
-      </Content>
-    </Screen>
+    <PageLayout>
+      <Screen>
+        <Content>
+          <Header year={year} onYearChange={setYear} />
+          <CardWrap>
+            <CalendarCard
+              year={year}
+              month={month}
+              onPrevMonth={goPrevMonth}
+              onNextMonth={goNextMonth}
+              onSelectDate={setSelectedDate}
+              selectedDay={selectedDate}
+            />
+          </CardWrap>
+          <Fab onClick={() => navigate(`/diary/new?date=${yyyyMmDd}`)}>
+            <img src={AddIcon} alt="새 기록 추가" />
+          </Fab>
+        </Content>
+      </Screen>
+    </PageLayout>
   );
 }
 

--- a/src/pages/diary/DiaryDetailPage.jsx
+++ b/src/pages/diary/DiaryDetailPage.jsx
@@ -1,0 +1,312 @@
+﻿import { useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import styled from "styled-components";
+
+import PageLayout from "../../components/layout/PageLayout";
+import { fetchDiaryDetail } from "../../lib/api/diary";
+
+const BackMark = "/arrow_left_black.svg";
+const MapPin = "/location_brown.svg";
+
+const CANVAS_W = 330;
+const CANVAS_H = 235;
+
+function formatVisitDate(value) {
+  if (!value) return "날짜 정보 없음";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "날짜 정보 없음";
+  const month = d.getMonth() + 1;
+  const day = d.getDate();
+  const weekday = d.toLocaleDateString("ko-KR", { weekday: "long" });
+  return `${month}월 ${day}일 ${weekday}`;
+}
+
+function drawStrokeOnCtx(ctx, stroke) {
+  const points = Array.isArray(stroke?.points) ? stroke.points : [];
+  if (points.length < 2) return;
+
+  ctx.save();
+  ctx.lineWidth = stroke?.size ?? 1;
+  ctx.lineCap = "round";
+  ctx.lineJoin = "round";
+
+  if (stroke?.tool === "eraser") {
+    ctx.globalCompositeOperation = "destination-out";
+  } else {
+    ctx.globalCompositeOperation = "source-over";
+    ctx.strokeStyle = stroke?.color ?? "#000000";
+  }
+
+  ctx.beginPath();
+  ctx.moveTo(points[0].x, points[0].y);
+  for (let i = 1; i < points.length; i += 1) {
+    ctx.lineTo(points[i].x, points[i].y);
+  }
+  ctx.stroke();
+  ctx.restore();
+}
+
+export default function DiaryDetailPage() {
+  const nav = useNavigate();
+  const { diaryId } = useParams();
+  const canvasRef = useRef(null);
+
+  const [diary, setDiary] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadDiary() {
+      if (!diaryId) return;
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const data = await fetchDiaryDetail(diaryId);
+        if (!cancelled) setDiary(data ?? null);
+      } catch (err) {
+        if (!cancelled) {
+          console.error("[DiaryDetailPage]", err);
+          setError(err);
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    }
+
+    loadDiary();
+    return () => {
+      cancelled = true;
+    };
+  }, [diaryId]);
+
+  const drawingStrokes = useMemo(() => {
+    if (!diary?.drawingData) return [];
+    try {
+      const parsed = JSON.parse(diary.drawingData);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch (err) {
+      console.error("[DiaryDetailPage] drawingData parse failed", err);
+      return [];
+    }
+  }, [diary?.drawingData]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
+    drawingStrokes.forEach((stroke) => drawStrokeOnCtx(ctx, stroke));
+  }, [drawingStrokes]);
+
+  const imageUrl = diary?.pictureUrls?.[0] || diary?.thumbnailUrl || "";
+
+  return (
+    <PageLayout frameStyle={`align-items: stretch; background: #FFFCF5; overflow: hidden;`}>
+      <Screen>
+        <Header>
+          <BackButton type="button" onClick={() => nav(-1)} aria-label="back">
+            <BackIcon src={BackMark} alt="뒤로가기" />
+          </BackButton>
+          <Title>다이어리</Title>
+          <Spacer />
+        </Header>
+
+        <Main>
+          {isLoading && <Message>불러오는 중...</Message>}
+
+          {!isLoading && error && (
+            <Message>다이어리를 불러오지 못했어요.</Message>
+          )}
+
+          {!isLoading && !error && diary && (
+            <>
+              <DateBox>
+                <DateText>{formatVisitDate(diary.visitDate)}</DateText>
+                <Divider />
+                <BakeryText>
+                  <Pin src={MapPin} alt="" />
+                  {diary.bakeryName || "빵집 정보 없음"}
+                </BakeryText>
+              </DateBox>
+
+              <DiaryTitle>{diary.title || ""}</DiaryTitle>
+
+              <MediaFrame>
+                {imageUrl ? (
+                  <BackgroundImage src={imageUrl} alt="" />
+                ) : (
+                  <EmptyLabel>이미지가 없어요</EmptyLabel>
+                )}
+                <DrawingCanvas ref={canvasRef} width={CANVAS_W} height={CANVAS_H} />
+              </MediaFrame>
+
+              <ContentBox>{diary.content || ""}</ContentBox>
+            </>
+          )}
+        </Main>
+      </Screen>
+    </PageLayout>
+  );
+}
+
+const Screen = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
+const Header = styled.header`
+  height: calc(56px + env(safe-area-inset-top, 0px) + 8px);
+  padding: calc(env(safe-area-inset-top, 0px) + 8px) 14px 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const BackButton = styled.button`
+  width: 36px;
+  height: 36px;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0;
+`;
+
+const BackIcon = styled.img`
+  width: 100%;
+  display: block;
+`;
+
+const Title = styled.h1`
+  margin: 0;
+  font-size: 18px;
+  font-weight: 700;
+`;
+
+const Spacer = styled.div`
+  width: 36px;
+  height: 36px;
+`;
+
+const Main = styled.main`
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+  padding-bottom: calc(20px + env(safe-area-inset-bottom, 0px));
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const Message = styled.p`
+  margin: 0;
+  text-align: center;
+  color: #7a6b58;
+  font-size: 14px;
+`;
+
+const DateBox = styled.div`
+  width: 100%;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  border-radius: 10px;
+  border: 1px solid #ab9d8b;
+`;
+
+const DateText = styled.div`
+  width: 150px;
+  padding: 0 14px;
+  font-size: 14px;
+  color: #000000;
+  white-space: nowrap;
+`;
+
+const Divider = styled.div`
+  width: 1px;
+  height: 60px;
+  background-color: #ab9d8b;
+`;
+
+const BakeryText = styled.div`
+  flex: 1;
+  padding-left: 14px;
+  font-size: 13px;
+  color: #000000;
+`;
+
+const Pin = styled.img`
+  width: 16px;
+  height: 15px;
+  margin-right: 6px;
+  vertical-align: middle;
+`;
+
+const DiaryTitle = styled.h2`
+  margin: 0;
+  padding: 0 12px;
+  font-size: 22px;
+  color: #ab9d8b;
+  font-weight: 500;
+`;
+
+const MediaFrame = styled.div`
+  position: relative;
+  width: 330px;
+  max-width: 100%;
+  height: 235px;
+  margin: 0 auto;
+  border-radius: 10px;
+  border: 1.5px solid #ab9d8b;
+  overflow: hidden;
+  background: #ffffff;
+`;
+
+const BackgroundImage = styled.img`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+`;
+
+const EmptyLabel = styled.div`
+  width: 100%;
+  height: 100%;
+  display: grid;
+  place-items: center;
+  color: #ab9d8b;
+  font-size: 13px;
+`;
+
+const DrawingCanvas = styled.canvas`
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+`;
+
+const ContentBox = styled.pre`
+  margin: 0;
+  width: 100%;
+  min-height: 200px;
+  padding: 6px 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 16px;
+  line-height: 36px;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 34.5px,
+    #ab9d8b 34.5px,
+    #ab9d8b 36px
+  );
+`;

--- a/src/pages/diary/DiaryDetailPage.jsx
+++ b/src/pages/diary/DiaryDetailPage.jsx
@@ -98,7 +98,9 @@ export default function DiaryDetailPage() {
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
     ctx.clearRect(0, 0, CANVAS_W, CANVAS_H);
-    drawingStrokes.forEach((stroke) => drawStrokeOnCtx(ctx, stroke));
+    drawingStrokes.forEach((stroke) => {
+      drawStrokeOnCtx(ctx, stroke);
+    });
   }, [drawingStrokes]);
 
   const imageUrl = diary?.pictureUrls?.[0] || diary?.thumbnailUrl || "";

--- a/src/pages/diary/DiaryEditorPage.jsx
+++ b/src/pages/diary/DiaryEditorPage.jsx
@@ -1,5 +1,5 @@
-import { useMemo, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+﻿import { useMemo, useEffect, useState, useCallback } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import PageLayout from "../../components/layout/PageLayout";
 
@@ -7,6 +7,8 @@ import { useDiaryEditorStore } from "../../store/diaryEditorStore";
 import DiaryHeader from "../../components/diary/EditorHeader";
 import DiaryEditorForm from "../../components/diary/EditorForm";
 import EditorTabBar from "../../components/diary/EditorTabBar";
+import { createDiary } from "../../lib/api/diary";
+import { uploadReviewPhoto } from "../../lib/api/imgUpload";
 
 function isValidYYYYMMDD(dateStr) {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
@@ -20,9 +22,32 @@ function isValidYYYYMMDD(dateStr) {
   return `${yyyy}-${mm}-${dd}` === dateStr;
 }
 
+function toVisitDateISOString(dateStr) {
+  return new Date(`${dateStr}T00:00:00`).toISOString();
+}
+
+function normalizeAddress(address) {
+  return {
+    detail: address?.detail ?? "",
+    lotNumber: address?.lotNumber ?? "",
+    roadAddress: address?.roadAddress ?? "",
+  };
+}
+
 export default function DiaryEditorPage() {
   const { search } = useLocation();
+  const navigate = useNavigate();
+
   const setDate = useDiaryEditorStore((s) => s.setDate);
+  const resetEditor = useDiaryEditorStore((s) => s.resetEditor);
+  const diaryDate = useDiaryEditorStore((s) => s.date);
+  const bakery = useDiaryEditorStore((s) => s.bakery);
+  const title = useDiaryEditorStore((s) => s.title);
+  const content = useDiaryEditorStore((s) => s.content);
+  const isPublic = useDiaryEditorStore((s) => s.isPublic);
+  const baseImage = useDiaryEditorStore((s) => s.baseImage);
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const { dateStr, isValid } = useMemo(() => {
     const params = new URLSearchParams(search);
@@ -37,12 +62,79 @@ export default function DiaryEditorPage() {
     setDate(dateStr);
   }, [isValid, dateStr, setDate]);
 
+  const handleSubmit = useCallback(async () => {
+    if (isSubmitting) return;
+
+    if (!diaryDate) {
+      alert("방문 날짜를 먼저 선택해주세요.");
+      return;
+    }
+
+    if (!bakery?.bakeryId || !bakery?.name) {
+      alert("빵집을 먼저 선택해주세요.");
+      return;
+    }
+
+    if (!title.trim()) {
+      alert("제목을 입력해주세요.");
+      return;
+    }
+
+    if (!content.trim()) {
+      alert("내용을 입력해주세요.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const pictureUrls = [];
+
+      if (typeof baseImage === "string" && baseImage) {
+        pictureUrls.push(baseImage);
+      } else if (baseImage) {
+        const uploadedUrl = await uploadReviewPhoto({ file: baseImage });
+        pictureUrls.push(uploadedUrl);
+      }
+
+      await createDiary({
+        bakeryId: bakery.bakeryId,
+        isPublic,
+        address: normalizeAddress(bakery.address),
+        thumbnail: "",
+        title: title.trim(),
+        visitDate: toVisitDateISOString(diaryDate),
+        content: content.trim(),
+        hashtags: [],
+        pictureUrls,
+      });
+
+      resetEditor();
+      navigate("/mydiary", { replace: true });
+    } catch (err) {
+      const msg =
+        err?.response?.data?.message ||
+        err?.message ||
+        "다이어리 저장에 실패했어요. 다시 시도해주세요.";
+      alert(msg);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [
+    isSubmitting,
+    diaryDate,
+    bakery,
+    title,
+    content,
+    baseImage,
+    isPublic,
+    resetEditor,
+    navigate,
+  ]);
+
   if (!isValid) {
     return (
-      <PageLayout
-        frameStyle={`align-items: stretch; background: #FFFCF5
-    `}
-      >
+      <PageLayout frameStyle={`align-items: stretch; background: #FFFCF5`}>
         <Content>
           <ErrorCard>
             <p>유효하지 않은 날짜로 접근했어요.</p>
@@ -60,7 +152,7 @@ export default function DiaryEditorPage() {
     `}
     >
       <Content>
-        <DiaryHeader />
+        <DiaryHeader onSubmit={handleSubmit} isSubmitting={isSubmitting} />
         <DiaryEditorForm />
       </Content>
       <EditorTabBar />
@@ -75,7 +167,6 @@ const Content = styled.div`
   -webkit-overflow-scrolling: touch;
 
   padding: 16px;
-  /* 탭바 높이(~80px) + safe area 여유분 */
   padding-bottom: calc(100px + env(safe-area-inset-bottom, 0px));
   box-sizing: border-box;
 

--- a/src/pages/diary/DiaryEditorPage.jsx
+++ b/src/pages/diary/DiaryEditorPage.jsx
@@ -23,7 +23,8 @@ function isValidYYYYMMDD(dateStr) {
 }
 
 function toVisitDateISOString(dateStr) {
-  return new Date(`${dateStr}T00:00:00`).toISOString();
+  const [yyyy, mm, dd] = dateStr.split("-").map(Number);
+  return new Date(Date.UTC(yyyy, mm - 1, dd)).toISOString();
 }
 
 function normalizeAddress(address) {

--- a/src/pages/diary/DiaryEditorPage.jsx
+++ b/src/pages/diary/DiaryEditorPage.jsx
@@ -46,6 +46,7 @@ export default function DiaryEditorPage() {
   const content = useDiaryEditorStore((s) => s.content);
   const isPublic = useDiaryEditorStore((s) => s.isPublic);
   const baseImage = useDiaryEditorStore((s) => s.baseImage);
+  const strokes = useDiaryEditorStore((s) => s.strokes);
 
   const [isSubmitting, setIsSubmitting] = useState(false);
 
@@ -105,6 +106,7 @@ export default function DiaryEditorPage() {
         title: title.trim(),
         visitDate: toVisitDateISOString(diaryDate),
         content: content.trim(),
+        drawingData: JSON.stringify(strokes ?? []),
         hashtags: [],
         pictureUrls,
       });
@@ -127,6 +129,7 @@ export default function DiaryEditorPage() {
     title,
     content,
     baseImage,
+    strokes,
     isPublic,
     resetEditor,
     navigate,

--- a/src/store/diaryEditorStore.js
+++ b/src/store/diaryEditorStore.js
@@ -15,6 +15,7 @@ const initialState = {
   tool: "pen",
   color: "#E33B3B",
   brushSize: 8,
+  textFont: "pretendard",
 
   activeTab: null, // 'font' | 'text' | 'image' | 'sticker' | 'tag' | 'draw' | null
   isPublic: false,
@@ -43,6 +44,7 @@ export const useDiaryEditorStore = create((set, get) => ({
   setTool: (tool) => set({ tool }),
   setColor: (color) => set({ color }),
   setBrushSize: (brushSize) => set({ brushSize }),
+  setTextFont: (textFont) => set({ textFont }),
 
   // 같은 탭 재클릭 시 닫기 (image 탭은 토글 없이 항상 파일 picker)
   setActiveTab: (tab) =>


### PR DESCRIPTION
## ✨ 구현한 기능
- diary post api 연결
- 그림 데이터는 JSON을 string으로 변환해 백엔드 전달
- diary 상세 조회 페이지 제작 + get api 연결

## 📢 논의하고 싶은 내용
- json을 계속 string으로 프론트에서 변홚해서 줄지, 백엔드 로직에 추가할지

## 🎸 기타
- 글꼴 변경 기능 추가 필요(현재 프론트에서만 적용되고 api에 넘기는 필드 없음)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Font selection in the diary editor (multiple fonts) and applied to title/content.
  * Diary detail view showing full entries, images, and rendered drawings.
  * Bakery selection integrated into diary creation flow.

* **Improvements**
  * Enhanced diary submission flow with loading/disable state and client-side validation.
  * Community navigation now opens selected diary entries.
  * Cleaner address display and minor layout/placeholder refinements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->